### PR TITLE
Adicionado libssl-dev as dependências do sistema operacional

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ E então, basta acessar _http://localhost:5000/_
 ## Sistemas Linux Debian-based
 É necessára a instalação de um pacote de desenvolvimento para a instalação correta do Lektor e das outras dependências. Para isso, basta executar:
 ```
-sudo apt-get install libffi-dev
+sudo apt-get install libffi-dev libssl-dev
 ```
 
 ## Buildando


### PR DESCRIPTION
Tentei rodar o projeto seguindo as instruções do README e o pip retornava o seguinte erro:

`fatal error: openssl/aes.h: Arquivo ou diretório não encontrado`

Corrigi instalando o pacote libssl-dev (além do libffi-dev que já havia instalado).

Dessa forma, inclui o pacote no comando apt-get do README.

```
sudo apt-get install libffi-dev libssl-dev
```
