### PR TITLE
Incluido configuração para CNAME do gh-pages

### DIFF
--- a/pythonrio.lektorproject
+++ b/pythonrio.lektorproject
@@ -2,4 +2,4 @@
 name = pythonrio
 
 [servers.ghpages]
-target = ghpages+https://pythonrio/pythonrio.github.io
+target = ghpages+https://pythonrio/pythonrio.github.io?cname=pythonrio.python.org.br


### PR DESCRIPTION
Inclui nas opções do lektor o parametro cname.

Assim o site hospedado no gh-pages pode utilizar um domínio próprio, no caso pythonrio.python.org.br

Isso tem por objetivo padronizar a url com a url dos outros grupy existentes.

As configurações de DNS já foram feitas, só é necessário essa configuração para alterar o url do site.

É importante observar que os links não ficarão quebrados, o gh-pages redireciona as urls do domínio antigo para o novo, por exemplo: http://grupydf.github.io/comunidade redireciona para http://df.python.org.br/comunidade
