### PR TITLE
Feature/agenda atividades

### DIFF
--- a/content/contents.lr
+++ b/content/contents.lr
@@ -1,189 +1,40 @@
 _model: page.ini
 ---
-date: 25 de Junho de 2016
+date: 30 de Julho de 2016
 ---
 title: Meetup PythOnRio
 ---
-address: Rua Santa Luzia, 735, 7º andar
+address: 
 ---
-city: Rio de Janeiro
+city: 
 ---
-local: Senac
+local: 
 ---
-neighborhood: Centro
+neighborhood: 
 ---
 description:
 
-Aeer \o/
+A comunidade Python do Rio de Janeiro tem um encontro marcado todo último sábado de cada mês.
+Seja no Centro ou na Barra, sinta-se convidado para comparecer e marcar presença no melhor encontro de comunidade da cidade \o//
 
-Já estão abertas as inscrições pro nosso próximo encontro! Será dia 25/06 no Senac! Contamos com a presença de vocês para tornar este o melhor encontro de comunidade do Rio!!
-
-Além das palestras, vamos fazer as lightning talks, que são palestras rápidas inscritas no momento do evento (você pode levar a sua). Dessa vez, o evento começará mais cedo e terá um monte de palestras sensacionais sobre Big Data, python3, infraestrutura, experiências de vida e design de código. Tudo para a nossa troca de experiências mensal e crescimento profissional.
-
-E ainda teremos um workshop incrível do Luiz Costa sobre programação orientada a objetos!
-
-Estamos acertando a ordem das palestras, mas já, já atualizaremos vocês. A organização será:
-
-09:00 às 10:00 - Credenciamento
-
-10:00 - Luiz Costa - Workshop Programação orientada a objetos!
-
-10:00 - Elias Dorneles - Coisas que aprendi portando código para Python 3
-
-10:50 - Delermando Santos - Usando Kubernetes com sua aplicação Django
-
-11:40 - Lightning talks
-
-12:00 às 13:00 - Almoço
-
-13:00 - Luiz Filipe Nunes Cesar - Vivências interessantes na busca do futuro
-
-13:50 - Felippe Da Motta Raposo - Como event sourcing, CQRS e DDD podem te ajudar a construir melhores soluções!
-
-14:40 às 14:50 - Intervalo
-
-14:50 - Eduardo Le Masson - Venha para o mundo do Big Data
-
-15:40 - Encerramento + foto
-
-16:00 - Pós-evento
-
-O evento será no Senac Centro das 10:00 às 16:00, no auditório do 7º andar.
-
-Nos vemos lá!
-
-Acompanhe-nos em nossas redes sociais para saber tudo sobre nossos encontros e as últimas novidades da comunidade Python.
+Acompanhe-nos também em nossas redes sociais para saber tudo sobre nossos encontros e as últimas novidades da comunidade Python.
 
 [+ Facebook](https://www.facebook.com/pythonrio)
 &nbsp; &nbsp;
 [+ Twitter](https://www.twitter.com/pythonrio)
 &nbsp; &nbsp;
 [+ Telegram](https://telegram.me/joinchat/AONs_ANlfCZRoXOX0QxEzA)
+&nbsp; &nbsp;
+[+ YouTube](https://www.youtube.com/channel/UCGl4xDZYUYGg4_aMah32yjQ)
 ---
-partners:
-
-#### partner ####
-name: Senac
-----
-url: http://rj.senac.br/
-----
-logo: /static/img/partners/senac.png
+partners: 
 ---
-url_callpapers:
+url_callpapers: 
 ---
-url_applications: http://www.eventbrite.com.br/e/python-rio-x-tickets-26132963397
+url_applications: 
 ---
-workshops:
-#### speaker ####
-talk: 10:00 - Workshop Programação orientada a objetos!
-----
-name:  Luiz Costa
-----
-at:
-----
-link:
-----
-bio: OBS: Para participar é aconselhável levar o seu laptop.
-----
-photo: /static/img/speakers/luizgmail.jpg
-
+workshops: 
 ---
-speakers:
-
-#### speaker ####
-
-talk: 10:00 - Coisas que aprendi portando código para Python 3
-----
-name: Elias Dorneles
-----
-at:
-----
-link: https://eliasdorneles.github.io/
-----
-bio: Compartilharei algumas coisas que aprendi portando código para funcionar em Python 3 mantendo retrocompatibilidade no Scrapy e em outros projetos open source em que colaboro.
-----
-photo: /static/img/speakers/eliasdorneles.png
-
-#### speaker ####
-
-talk: 10:50 - Usando Kubernetes com sua aplicação Django
-----
-name: Delermando Santos
-----
-at:
-----
-link: https://github.com/Delermando
-----
-bio: Nesta apresentação mostrarei como combinar o poder de orquestração de containers que o Kubernetes oferece levantando uma aplicação usando Django.
-----
-photo: /static/img/speakers/delemandosantos.jpg
-
-#### speaker ####
-
-talk: 11:40 - Lightning talks
-----
-name:
-----
-at:
-----
-link:
-----
-bio: Lightning talks é uma curta apresentação que dura apenas alguns minutos.
-----
-photo: /static/img/speakers/default.png
-
-#### speaker ####
-
-talk: 13:00 - Vivências interessantes na busca do futuro
-----
-name: Luiz Filipe Nunes Cesar
-----
-at:
-----
-link:
-----
-bio: Esta apresentação aborda como se empenhar e crescer apesar das dificuldades impostas pelos desafios do dia a dia. A trajetória de quem começou como call center e agora busca seu espaço no mundo da programação. Relato de casos abordando soluções e dificuldades vividas pela equipe de internet de uma empresa de grandes marcas.
-----
-photo: /static/img/speakers/luizfelippe.jpg
-
-#### speaker ####
-
-talk: 13:50 - Como event sourcing, CQRS e DDD podem te ajudar a construir melhores soluções!
-----
-name: Felippe Da Motta Raposo
-----
-at:
-----
-link: https://github.com/felippemr
-----
-bio: O que é event sourcing, CQRS(Command Query Responsibility) e DDD(Domain Driven Design)? Como eles podem me ajudar a solucionar problemas? Como posso aplicar esses conceitos ao desenvolvimento de sistemas distribuídos? Essas e outras perguntas serão exploradas na talk!
-----
-photo: /static/img/speakers/feliperaposo.jpg
-
-#### speaker ####
-
-talk: 14:50 - Venha para o mundo do Big Data
-----
-name: Eduardo Le Masson
-----
-at:
-----
-link:
-----
-bio: Introdução ao mundo Big Data para desenvolvedores Python. Principais aplicações de Data Products no mercado nacional e o perfil atual do profissional que as empresas buscam. Como as empresas podem se beneficiar com o uso inteligente dos dados que já possui, desenvolver um time interno sem ter que começar investindo alto com consultores e experts ? Como começar, onde estudar e obter experiências
-----
-photo: /static/img/speakers/eduardolemasson.jpg
-
-#### speaker ####
-
-talk: 16:00 - Pós-evento
-----
-name:
-----
-at:
-----
-link:
-----
-bio: Vamos trocar ideias e beber um chopp.
-----
-photo: /static/img/speakers/default.png
+speakers: 
+---
+activities: 

--- a/flowblocks/activity.ini
+++ b/flowblocks/activity.ini
@@ -1,0 +1,18 @@
+[block]
+name = Activity Block
+button_label = Atividades
+
+[fields.name]
+label = Activity Title
+description = Titulo da palestra ou workshop
+type = string
+
+[fields.local]
+label = Activity Local
+description = Local da atividade. Ex: Sala 501, Auditório 2, etc.
+type = string
+
+[fields.time]
+label = Activity schedule
+description = Horário da atividade
+type = string

--- a/models/page.ini
+++ b/models/page.ini
@@ -51,6 +51,11 @@ label = Palestrantes
 type = flow
 flow_blocks = speaker
 
+[fields.activities]
+label = Atividades
+type = flow
+flow_blocks = activity
+
 [fields.partners]
 label = Parceiros
 type = flow

--- a/templates/includes/navigation-bar.html
+++ b/templates/includes/navigation-bar.html
@@ -5,6 +5,7 @@
         ['/#about', 'Sobre'],
         ['/#location', 'Localização'],
         ['/#speakers', 'Palestras'],
+        ['/#agenda', 'Agenda'],
         ['/#partners', 'Parceiros'],
 	['/blog/', 'Blog'],
     ['/events/', 'Edições Anteriores']

--- a/templates/includes/sections/activities.html
+++ b/templates/includes/sections/activities.html
@@ -1,0 +1,30 @@
+{% if this.activities %}
+<section class="agenda" id="agenda">
+    <h2 class="section-title">Agenda</h2>
+
+    {% if this.activities|trim %}
+    <div class="schedule-tbl">
+      <table>
+        <thead>
+          <tr>
+            <th class="schedule-time">Hora</th>
+            <th class="schedule-slot">Local</th>
+            <th class="schedule-description">Atividade</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for activity in this.activities.blocks %}
+        <tr class="schedule-other">
+          <td class="schedule-time">{{ activity.time }}</td>
+          <td class="schedule-slot">{{ activity.local }}</td>
+          <td class="schedule-description">{{ activity.name }}</td>
+        </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
+</section>
+{% endif %}
+
+

--- a/templates/includes/sections/speakers.html
+++ b/templates/includes/sections/speakers.html
@@ -1,4 +1,4 @@
-{% if this.url_callpapers or this.speakers %}
+{% if this.url_callpapers|trim or this.speakers %}
 <section class="speakers" id="speakers">
     <h2 class="section-title">Palestras</h2>
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -14,6 +14,7 @@
         {% include 'includes/sections/location.html' %}
         {% include 'includes/sections/workshops.html' %}
         {% include 'includes/sections/speakers.html' %}
+        {% include 'includes/sections/activities.html' %}
         {% include 'includes/sections/partners.html' %}
 
     </div>


### PR DESCRIPTION
## Implementa agenda de atividades do evento

Agora, a agenda de atividades possui um bloco próprio. Nesse bloco podemos definir o horário e local da palestra/workshop. 
![captura de tela de 2016-06-30 23-39-38](https://cloud.githubusercontent.com/assets/2524981/16510509/164babf4-3f1d-11e6-8990-ea0a3f074352.png)

As atividades serão renderizadas no template em espaço próprio, não sendo mais necessário colocá-las na seção _Sobre_
![captura de tela de 2016-06-30 23-40-51](https://cloud.githubusercontent.com/assets/2524981/16510511/1b8aea8a-3f1d-11e6-9548-03abb456ba36.png)
