### PR TITLE
Remove espaços desnecessários

### DIFF
--- a/content/evento/contents.lr
+++ b/content/evento/contents.lr
@@ -72,7 +72,7 @@ name:  apistar: Novo framework REST do criador do DRF - Luciano Ratamero
 ----
 time: 16:00
 #### activity ####
-name: Deus ex machina, robôs por todos os lados. Volume 2 - Euclides da Cu  nha
+name: Deus ex machina, robôs por todos os lados. Volume 2 - Euclides da Cunha
 ----
 time: 16:50
 #### activity ####


### PR DESCRIPTION
O nome do palestrante estava com uns espaços e ficou muito feio no front.